### PR TITLE
Add release plug ins for publishing to Maven Central

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,7 +1,11 @@
 import java.util.jar._
 import sbt._
 import sbt.Keys._
-
+import sbtrelease.ReleasePlugin._
+import sbtrelease._
+import ReleaseStateTransformations._
+import xerial.sbt.Sonatype._
+import com.typesafe.sbt.pgp._
 
 object Build extends Build {
 
@@ -9,8 +13,45 @@ object Build extends Build {
     organization := "com.gu",
     scalaVersion := "2.10.4",
     crossScalaVersions := Seq("2.10.4", "2.11.2"),
-    version      := "0.2-SNAPSHOT",
     scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings")
+  )
+
+  val publishSettings = releaseSettings ++ sonatypeSettings ++ Seq(
+    scmInfo := Some(ScmInfo(
+      url("https://github.com/bmjames/json4s-zipper"),
+      "scm:git:git@github.com:bmjames/json4s-zipper.git"
+    )),
+    pomExtra := (
+      <url>https://github.com/bmjames/json4s-zipper</url>
+          <developers>
+        <developer>
+        <id>bmjames</id>
+        <name>Ben James</name>
+        <url>https://github.com/bmjames</url>
+          </developer>
+        </developers>
+    ),
+    licenses := Seq(
+      "Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")
+    ),
+    ReleaseKeys.crossBuild := true,
+    ReleaseKeys.releaseProcess := Seq[ReleaseStep](
+      checkSnapshotDependencies,
+      inquireVersions,
+      runClean,
+      runTest,
+      setReleaseVersion,
+      commitReleaseVersion,
+      tagRelease,
+      ReleaseStep(
+        action = state => Project.extract(state).runTask(PgpKeys.publishSigned, state)._1,
+        enableCrossBuild = true
+      ),
+      setNextVersion,
+      commitNextVersion,
+      ReleaseStep(state => Project.extract(state).runTask(SonatypeKeys.sonatypeReleaseAll, state)._1),
+      pushChanges
+    )
   )
 
   val scalazVersion = "7.1.0"
@@ -23,20 +64,25 @@ object Build extends Build {
     .settings(commonSettings ++ publishSettings: _*)
     .settings(
       name := "json-zipper-core",
+      description := "JSON Zipper core library",
       libraryDependencies += "org.scalaz" %% "scalaz-core" % scalazVersion
     )
 
   val scalacheckBinding = Project("scalacheck-binding", file("scalacheck-binding"))
     .dependsOn(core)
     .settings(commonSettings ++ publishSettings: _*)
-    .settings(name := "json-zipper-scalacheck-binding")
-    .settings(libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion)
+    .settings(
+      name := "json-zipper-scalacheck-binding",
+      description := "JSON Zipper ScalaCheck binding",
+      libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion
+    )
 
   val json4s = Project("json4s", file("json4s"))
     .dependsOn(core, scalacheckBinding)
     .settings(commonSettings ++ publishSettings: _*)
     .settings(
       name := "json-zipper-json4s",
+      description := "JSON Zipper Json4s binding",
       libraryDependencies ++= Seq(
         "org.json4s" %% "json4s-core" % json4sVersion,
         "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
@@ -47,6 +93,7 @@ object Build extends Build {
     .settings(commonSettings ++ publishSettings: _*)
     .settings(
       name := "json-zipper-play",
+      description := "JSON Zipper Play binding",
       resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play-json" % playVersion,
@@ -65,23 +112,4 @@ object Build extends Build {
   val root = Project("root", file("."))
     .settings(commonSettings: _*)
     .aggregate(core, json4s, play, scalacheckBinding, test)
-
-  def publishSettings = Seq(
-    publishArtifact := true,
-    packageOptions <+= (version, name) map { (v, n) =>
-      Package.ManifestAttributes(
-        Attributes.Name.IMPLEMENTATION_VERSION -> v,
-        Attributes.Name.IMPLEMENTATION_TITLE -> n,
-        Attributes.Name.IMPLEMENTATION_VENDOR -> "guardian.co.uk"
-      )
-    },
-    publishTo <<= version { version: String =>
-      val publishType = if (version.endsWith("SNAPSHOT")) "snapshots" else "releases"
-      Some(Resolver.file(
-        "guardian github " + publishType,
-        file(System.getProperty("user.home") + "/guardian.github.com/maven/repo-" + publishType)
-      ))
-    }
-  )
-
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.2-SNAPSHOT"


### PR DESCRIPTION
We publish to Maven Central nowadays ...

This adds the stuff to do so. Just wanted to give you the chance to review both the descriptions and the license before I actually do a release. (I wouldn't suggest actually merging this until I've successfully done the release, as there might be things I need to fix ... )
